### PR TITLE
Disable forbidden proptypes rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,7 @@ module.exports = {
   },
   rules: {
     'max-len': 'off', // Remove warnings on max line length exceeding 100 characters
+    'react/forbid-prop-types': 'off', // Disabled to allow for the use of any React PropType
     'react/require-default-props': 'off', // Disabled the requirement to default all non-required props
     'compat/compat': 'error',
   },


### PR DESCRIPTION
### Summary
When using module, lint errors for PropType `object` , `array` is forbidden are thrown. Terra has no preference on the PropTypes used in our components.