### PR TITLE
Eslint 5 compat update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ ChangeLog
 
 Unreleased
 -----------------
+### Changed
+* Update dependencies to ESLint v5 compatible versions
+* Disabled the deprecated `jsx-a11y/label-has-for rule`. More info about this rule deprecation here: https://github.com/evcohen/eslint-plugin-jsx-a11y/releases/tag/v6.1.0
+* Replaced `jsx-a11y/label-has-for` rule with new `jsx-a11y/label-has-associated-control`.
+* Disabled react/destructuring-assignment.
 
 1.1.0 - (July 11, 2018)
 ------------------

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,4 +1,4 @@
-// eslint-disable-next-line import/no-extraneous-dependencies, no-unused-vars
+// eslint-disable-next-line import/no-extraneous-dependencies, no-unused-vars, object-curly-newline
 import { danger, warn, fail, message } from 'danger';
 
 const modifiedChangelog = danger.git.modified_files.filter((filePath) => {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,10 +22,8 @@ module.exports = {
     // Replaces jsx-a11y/label-has-for rule. By default, it wants inputs to be both wrapped in a label
     // and include a id/for attribute mapping with label.
     // This config updates the rule to require one or the other.
-    "jsx-a11y/label-has-associated-control": [2, {
-      "assert": "either"
-    }],
-    "react/destructuring-assignment": 'off',
+    'jsx-a11y/label-has-associated-control': [2, { assert: 'either' }],
+    'react/destructuring-assignment': 'off',
   },
   globals: {
     shallow: true,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,14 +11,21 @@ module.exports = {
     jest: true,
   },
   rules: {
-    'max-len': 'off', // Remove warnings on max line length exceeding 100 characters
-    'react/require-default-props': 'off', // Disabled the requirement to default all non-required props
+    // Remove warnings on max line length exceeding 100 characters
+    'max-len': 'off',
+    // Disabled the requirement to default all non-required props
+    'react/require-default-props': 'off',
     'compat/compat': 'error',
-    'jsx-a11y/label-has-for': [2, {
-      required: {
-        some: ['nesting', 'id'],
-      },
+    // Disable this rule as it has been marked as deprecated in jsx-a11y plugin
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/releases/tag/v6.1.0
+    'jsx-a11y/label-has-for': 'off',
+    // Replaces jsx-a11y/label-has-for rule. By default, it wants inputs to be both wrapped in a label
+    // and include a id/for attribute mapping with label.
+    // This config updates the rule to require one or the other.
+    "jsx-a11y/label-has-associated-control": [2, {
+      "assert": "either"
     }],
+    "prefer-destructuring": 'off',
   },
   globals: {
     shallow: true,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,7 +25,7 @@ module.exports = {
     "jsx-a11y/label-has-associated-control": [2, {
       "assert": "either"
     }],
-    "prefer-destructuring": 'off',
+    "react/destructuring-assignment": 'off',
   },
   globals: {
     shallow: true,

--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
     "eslint": "^5.0.0",
     "rimraf": "^2.6.1",
     "shelljs": "^0.7.7"
+  },
+  "eslintConfig": {
+    "extends": "./eslint.config.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,18 +29,18 @@
     "release:patch": "node scripts/release/release.js patch"
   },
   "dependencies": {
-    "eslint-config-airbnb": "^16.1.0",
-    "eslint-plugin-compat": "^2.3.0",
-    "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-jsx-a11y": "^6.0.3",
-    "eslint-plugin-react": "^7.9.1"
+    "eslint-config-airbnb": "^17.1.0",
+    "eslint-plugin-compat": "^2.5.1",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-jsx-a11y": "^6.1.1",
+    "eslint-plugin-react": "^7.11.0"
   },
   "peerDependencies": {
-    "eslint": "^4.19.1"
+    "eslint": "^5.0.0"
   },
   "devDependencies": {
     "danger": "^3.7.14",
-    "eslint": "^4.19.1",
+    "eslint": "^5.0.0",
     "rimraf": "^2.6.1",
     "shelljs": "^0.7.7"
   }


### PR DESCRIPTION
### Summary
* Update dependencies to ESLint v5 compatible versions
* Disabled deprecated `jsx-a11y/label-has-for` rule. More info about this rule deprecation here: https://github.com/evcohen/eslint-plugin-jsx-a11y/releases/tag/v6.1.0
* Replaced `jsx-a11y/label-has-for` rule with new `jsx-a11y/label-has-associated-control`. By default, this rule wants inputs to be both wrapped in a label and include a id/for attribute mapping with label. This config updates the rule to require one or the other.
* Disabled `react/destructuring-assignment`.