### PR TITLE
Temp lock down eslint-plugin-react

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Unreleased
 
 ### Changed
 * Added after as globals for test files recursively under a "wdio" directory
+* Tempararily lock-down `eslint-plugin-react`. V7.12.0 was released with bugs and has not yet been fixed. Locking this down until a fix is released.
 
 2.1.0 - (August 29, 2018)
 ------------------

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-compat": "^2.5.1",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.1",
-    "eslint-plugin-react": "^7.11.0"
+    "eslint-plugin-react": "7.11.0"
   },
   "peerDependencies": {
     "eslint": "^5.0.0"


### PR DESCRIPTION
### Summary
`eslint-plugin-react` 7.12.0 was released with bugs. It has not yet been fixed so we should lock this down until a fix is released.

