### PR TITLE
Add a warning to discourage inline styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ ChangeLog
 Unreleased
 -----------------
 
+### Added
+* A warning to discourage inline styles 
+
 2.4.0 - (February 11, 2019)
 -----------------
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,8 +4,10 @@ Cerner Corporation
 - Matt Henkes [@mjhenkes]
 - Brett Jankord [@bjankord]
 - Daniel Vu [@dv297]
+- Stephen Esser [@StephenEsser]
 
 [@emilyrohrbough]: https://github.com/emilyrohrbough
 [@mjhenkes]: https://github.com/mjhenkes
 [@bjankord]: https://github.com/bjankord
 [@dv297]: https://github.com/dv297
+[@StephenEsser]: https://github.com/StephenEsser

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,11 +25,12 @@ module.exports = {
     // This config updates the rule to require one or the other.
     'jsx-a11y/label-has-associated-control': [2, { assert: 'either' }],
     'react/destructuring-assignment': 'off',
+    'react/forbid-component-props': [1, { forbid: ['style'] }],
+    'react/forbid-dom-props': [1, { forbid: ['style'] }],
     // This updates the rule below to throw a warning rather than an error
     // when using eslint-plugin-react 7.12.2 or above.
     'react/jsx-wrap-multilines': 'warn',
     'react-hooks/rules-of-hooks': 'error',
-    'react/forbid-component-props': [1, { forbid: ['style'] }],
   },
   settings: {
     polyfills: ['object-values'],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,14 +29,7 @@ module.exports = {
     // when using eslint-plugin-react 7.12.2 or above.
     'react/jsx-wrap-multilines': 'warn',
     'react-hooks/rules-of-hooks': 'error',
-    'react/forbid-component-props': [
-      1,
-      {
-        forbid: [
-          'style',
-        ],
-      },
-    ],
+    'react/forbid-component-props': [1, { forbid: ['style'] }],
   },
   settings: {
     polyfills: ['object-values'],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,6 +29,14 @@ module.exports = {
     // when using eslint-plugin-react 7.12.2 or above.
     'react/jsx-wrap-multilines': 'warn',
     'react-hooks/rules-of-hooks': 'error',
+    'react/forbid-component-props': [
+      1,
+      {
+        forbid: [
+          'style',
+        ],
+      },
+    ],
   },
   settings: {
     polyfills: ['object-values'],


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

There have been a few issues logged regarding the use of inline styles within our examples. Inline styles have the potential to create browser and theme incompatibilities and bugs.

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

There are *a lot* of inline examples within our monorepos. This rule will introduce ~398 warnings in terra-core and ~58 warnings in terra-clinical. I didn't check terra-framework, but I am sure it's a handful. 

It's possible to create our own rule for inline styles. This would allow us to have greater control over the message that is logged to the console. But it requires quite a bit of overhead. To create our own rule we would need to create another repository ( eslint-plugin-terra ) and then consume it from within eslint-config-terra. The trade-offs to using the already created rules makes it a lot easier, but we don't have control over the output message. I'll post an example output below.

### Lint Rules:

[forbid-component-props](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-component-props.md) - Forbids inline styles being used on React Components
[forbid-dom-props](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-dom-props.md) - Forbids styles being used on native dom elements

### Related Issues:
https://github.com/cerner/terra-clinical/issues/498
https://github.com/cerner/terra-core/issues/2386
https://github.com/cerner/terra-framework/issues/657

### Example Output

```
/terra/terra-clinical/packages/terra-clinical-item-view/src/terra-dev-site/test/clinical-item-view/AccessoryItemView.test.jsx
  10:8   warning  Prop `style` is forbidden on DOM Nodes   react/forbid-dom-props
  41:62  warning  Prop `style` is forbidden on Components  react/forbid-component-props
```


@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
