### PR TITLE
Update config to use eslint 6 / eslint-config-airbnb 18 / eslint-plugin-compat v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,15 @@ ChangeLog
 
 Unreleased
 -----------------
+### Breaking Changes
+* Updated eslint peer dependency to `^6.1.0`
+* Update eslint-config-airbnb
+dependency to `^18.0.0`
+* Update eslint-plugin-compat dependency to `^3.3.0`
+
 ### Changed
 * Replace DangerJS integration with probot-changelog
+* Removed rimraf devDependency and replaced with `rm -rf`
 
 2.5.0 - (May 9, 2019)
 -----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@ Unreleased
 -----------------
 ### Breaking Changes
 * Updated eslint peer dependency to `^6.1.0`
-* Update eslint-config-airbnb
-dependency to `^18.0.0`
+* Update eslint-config-airbnb dependency to `^18.0.0`
 * Update eslint-plugin-compat dependency to `^3.3.0`
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Unreleased
 * Updated eslint peer dependency to `^6.1.0`
 * Update eslint-config-airbnb dependency to `^18.0.0`
 * Update eslint-plugin-compat dependency to `^3.3.0`
+* Enable `react/jsx-wrap-multilines` rule
+* Updating warning for style prop to produce an error instead of a warning
 
 ### Changed
 * Replace DangerJS integration with probot-changelog

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,9 +27,6 @@ module.exports = {
     'react/destructuring-assignment': 'off',
     'react/forbid-component-props': [1, { forbid: ['style'] }],
     'react/forbid-dom-props': [1, { forbid: ['style'] }],
-    // This updates the rule below to throw a warning rather than an error
-    // when using eslint-plugin-react 7.12.2 or above.
-    'react/jsx-wrap-multilines': 'warn',
     'react-hooks/rules-of-hooks': 'error',
     'react/jsx-props-no-spreading': 'off',
     'react/state-in-constructor': 'off',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -31,6 +31,8 @@ module.exports = {
     // when using eslint-plugin-react 7.12.2 or above.
     'react/jsx-wrap-multilines': 'warn',
     'react-hooks/rules-of-hooks': 'error',
+    'react/jsx-props-no-spreading': 'off',
+    'react/state-in-constructor': 'off',
   },
   settings: {
     polyfills: ['object-values'],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,7 +35,12 @@ module.exports = {
     'react/state-in-constructor': 'off',
   },
   settings: {
-    polyfills: ['object-values'],
+    polyfills: [
+      'Object.assign',
+      'Object.values',
+      'Set',
+      'Map',
+    ],
   },
   overrides: [
     {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -36,10 +36,11 @@ module.exports = {
   },
   settings: {
     polyfills: [
+      'Map',
+      'Number.isNaN',
       'Object.assign',
       'Object.values',
       'Set',
-      'Map',
     ],
   },
   overrides: [

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,8 +25,8 @@ module.exports = {
     // This config updates the rule to require one or the other.
     'jsx-a11y/label-has-associated-control': [2, { assert: 'either' }],
     'react/destructuring-assignment': 'off',
-    'react/forbid-component-props': [1, { forbid: ['style'] }],
-    'react/forbid-dom-props': [1, { forbid: ['style'] }],
+    'react/forbid-component-props': [2, { forbid: ['style'] }],
+    'react/forbid-dom-props': [2, { forbid: ['style'] }],
     'react-hooks/rules-of-hooks': 'error',
     'react/jsx-props-no-spreading': 'off',
     'react/state-in-constructor': 'off',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,6 +33,8 @@ module.exports = {
     'react-hooks/rules-of-hooks': 'error',
     'react/jsx-props-no-spreading': 'off',
     'react/state-in-constructor': 'off',
+    'react/jsx-fragments': 'off',
+    'arrow-parens': 'off',
   },
   settings: {
     polyfills: [

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,6 +38,7 @@ module.exports = {
   },
   settings: {
     polyfills: [
+      'Array.from',
       'Map',
       'Number.isNaN',
       'Number.isInteger',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,6 +38,8 @@ module.exports = {
     polyfills: [
       'Map',
       'Number.isNaN',
+      'Number.isInteger',
+      'Number.parseFloat',
       'Object.assign',
       'Object.values',
       'Set',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -44,6 +44,7 @@ module.exports = {
       'Number.parseFloat',
       'Object.assign',
       'Object.values',
+      'Object.entries',
       'Set',
     ],
   },

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "release:patch": "npm version patch -m 'Released version %s' && npm publish"
   },
   "dependencies": {
+    "acorn": "^6.0.0",
     "eslint-config-airbnb": "^18.0.0",
     "eslint-plugin-compat": "^3.3.0",
     "eslint-plugin-import": "^2.14.0",

--- a/package.json
+++ b/package.json
@@ -20,29 +20,28 @@
   },
   "homepage": "https://github.com/cerner/eslint-config-terra",
   "scripts": {
-    "clean": "rimraf node_modules",
+    "clean": "rm -rf node_modules",
     "clean:install": "npm run clean && npm install",
     "lint": "eslint --ext .js,.jsx .",
-     "postpublish": "git push --tag",
+    "postpublish": "git push --tag",
     "prepublishOnly": "npm whoami && npm run lint",
     "release:major": "npm version major -m 'Released version %s' && npm publish",
     "release:minor": "npm version minor -m 'Released version %s' && npm publish",
     "release:patch": "npm version patch -m 'Released version %s' && npm publish"
   },
   "dependencies": {
-    "eslint-config-airbnb": "^17.1.0",
-    "eslint-plugin-compat": "^2.5.1",
+    "eslint-config-airbnb": "^18.0.0",
+    "eslint-plugin-compat": "^3.3.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.1",
     "eslint-plugin-react": "^7.12.2",
     "eslint-plugin-react-hooks": "^1.0.0"
   },
   "peerDependencies": {
-    "eslint": "^5.0.0"
+    "eslint": "^6.1.0"
   },
   "devDependencies": {
-    "eslint": "^5.0.0",
-    "rimraf": "^2.6.1"
+    "eslint": "^6.1.0"
   },
   "eslintConfig": {
     "extends": "./eslint.config.js"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "release:patch": "npm version patch -m 'Released version %s' && npm publish"
   },
   "dependencies": {
-    "acorn": "^6.0.0",
     "eslint-config-airbnb": "^18.0.0",
     "eslint-plugin-compat": "^3.3.0",
     "eslint-plugin-import": "^2.14.0",


### PR DESCRIPTION
### Summary
Resolves #31 
Resolves #35 
Resolves #23 

* Updated eslint peer dependency to `^6.1.0`
* Update eslint-config-airbnb dependency to `^18.0.0`
* Update eslint-plugin-compat dependency to `^3.3.0`