### PR TITLE
Update eslint-plugin-react-hooks to latest major release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 -----------------
+### Changed
+* Update eslint-plugin-react-hooks dependency to `^2.0.1`
 
 3.0.0 - (August 20, 2019)
 -----------------

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,6 +28,7 @@ module.exports = {
     'react/forbid-component-props': [2, { forbid: ['style'] }],
     'react/forbid-dom-props': [2, { forbid: ['style'] }],
     'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn',
     'react/jsx-props-no-spreading': 'off',
     'react/state-in-constructor': 'off',
     'react/jsx-fragments': 'off',

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.1",
     "eslint-plugin-react": "^7.12.2",
-    "eslint-plugin-react-hooks": "^1.0.0"
+    "eslint-plugin-react-hooks": "^2.0.1"
   },
   "peerDependencies": {
     "eslint": "^6.1.0"


### PR DESCRIPTION
### Summary
Update eslint-plugin-react-hooks to latest major release.

Related: https://github.com/facebook/react/pull/16528/files