### PR TITLE
Add rule override to warn on multiple consecutive empty lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 -----------------
+### Added
+* Added rule override for `no-multiple-empty-lines` to warn on multiple consecutive empty lines
 
 3.0.2 - (October 1, 2019)
 -----------------

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,7 +24,7 @@ module.exports = {
     // and include a id/for attribute mapping with label.
     // This config updates the rule to require one or the other.
     'jsx-a11y/label-has-associated-control': [2, { assert: 'either' }],
-    'no-multiple-empty-lines': [1, { "max": 1 }],
+    'no-multiple-empty-lines': [1, { max: 1 }],
     'react/destructuring-assignment': 'off',
     'react/forbid-component-props': [2, { forbid: ['style'] }],
     'react/forbid-dom-props': [2, { forbid: ['style'] }],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,6 +24,7 @@ module.exports = {
     // and include a id/for attribute mapping with label.
     // This config updates the rule to require one or the other.
     'jsx-a11y/label-has-associated-control': [2, { assert: 'either' }],
+    "no-multiple-empty-lines": [1, { "max": 1 }],
     'react/destructuring-assignment': 'off',
     'react/forbid-component-props': [2, { forbid: ['style'] }],
     'react/forbid-dom-props': [2, { forbid: ['style'] }],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,7 +24,7 @@ module.exports = {
     // and include a id/for attribute mapping with label.
     // This config updates the rule to require one or the other.
     'jsx-a11y/label-has-associated-control': [2, { assert: 'either' }],
-    "no-multiple-empty-lines": [1, { "max": 1 }],
+    'no-multiple-empty-lines': [1, { "max": 1 }],
     'react/destructuring-assignment': 'off',
     'react/forbid-component-props': [2, { forbid: ['style'] }],
     'react/forbid-dom-props': [2, { forbid: ['style'] }],


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

This PR adds a rule override to warn if multiple empty lines are detected.

https://eslint.org/docs/rules/no-multiple-empty-lines

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

The override has been added as a warning for passivity.

@cerner/terra