### PR TITLE
Set node engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 -----------------
+### Added
+* Added minimum node engine version of 8.10.0 or 10.13.0 in package.json
 
 3.1.0 - (October 30, 2019)
 -----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ ChangeLog
 Unreleased
 -----------------
 ### Added
-* Added minimum node engine version of 8.10.0 or 10.13.0 in package.json
+* Added minimum node engine version of 8.10.0, 10.13.0, or 11.10.1 in package.json
 
 3.1.0 - (October 30, 2019)
 -----------------

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,9 +5,11 @@ Cerner Corporation
 - Brett Jankord [@bjankord]
 - Daniel Vu [@dv297]
 - Stephen Esser [@StephenEsser]
+- Ben Cai [@benbcai]
 
 [@emilyrohrbough]: https://github.com/emilyrohrbough
 [@mjhenkes]: https://github.com/mjhenkes
 [@bjankord]: https://github.com/bjankord
 [@dv297]: https://github.com/dv297
 [@StephenEsser]: https://github.com/StephenEsser
+[@benbcai]: https://github.com/benbcai

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/cerner/eslint-config-terra/issues"
   },
   "engines": {
-    "node": "^8.10.0 || ^10.13.0"
+    "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
   },
   "homepage": "https://github.com/cerner/eslint-config-terra",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   "bugs": {
     "url": "https://github.com/cerner/eslint-config-terra/issues"
   },
+  "engines": {
+    "node": "^8.10.0 || ^10.13.0"
+  },
   "homepage": "https://github.com/cerner/eslint-config-terra",
   "scripts": {
     "clean": "rm -rf node_modules",


### PR DESCRIPTION
### Summary
- Fixes #42 
- Eslint v6 requires a minimum engine version of 8.10.0


@cerner/terra
