### PR TITLE
Updating config with new override for terra-dev-site examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ ChangeLog
 Unreleased
 -----------------
 
+### Added
+* Added new override for relative package imports within terra-dev-site example files
+
 3.2.0 - (November 7, 2019)
 -----------------
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,6 +6,7 @@ Cerner Corporation
 - Daniel Vu [@dv297]
 - Stephen Esser [@StephenEsser]
 - Ben Cai [@benbcai]
+- Tyler Biethman [@tbiethman]
 
 [@emilyrohrbough]: https://github.com/emilyrohrbough
 [@mjhenkes]: https://github.com/mjhenkes
@@ -13,3 +14,4 @@ Cerner Corporation
 [@dv297]: https://github.com/dv297
 [@StephenEsser]: https://github.com/StephenEsser
 [@benbcai]: https://github.com/benbcai
+[@tbiethman]: https://github.com/tbiethman

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -72,5 +72,13 @@ module.exports = {
         Terra: true,
       },
     },
+    {
+      "files": [
+        "**/*/terra-dev-site/**/*.jsx"
+      ],
+      "rules": {
+        "import/no-unresolved": "off",
+      },
+    },
   ],
 };

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -73,11 +73,9 @@ module.exports = {
       },
     },
     {
-      "files": [
-        "**/*/terra-dev-site/**/*.jsx"
-      ],
-      "rules": {
-        "import/no-unresolved": "off",
+      files: ['**/*/terra-dev-site/**/*.jsx'],
+      rules: {
+        'import/no-unresolved': 'off',
       },
     },
   ],


### PR DESCRIPTION
### Summary

A lot of our packages override this rule in their local eslint config overrides. By adding it here, those package-specific overrides can be removed.

Testing here: https://github.com/cerner/terra-core/pull/2806