### PR TITLE
Add full stack specs to lint overrides to allow test globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 -----------------
+### Added
+* Add full stack specs to lint overrides to ignore undefined global lint errors.
 
 3.3.0 - (January 28, 2020)
 -----------------

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,6 +7,7 @@ Cerner Corporation
 - Stephen Esser [@StephenEsser]
 - Ben Cai [@benbcai]
 - Tyler Biethman [@tbiethman]
+- Derek Yu [@yuderekyu]
 
 [@emilyrohrbough]: https://github.com/emilyrohrbough
 [@mjhenkes]: https://github.com/mjhenkes
@@ -15,3 +16,4 @@ Cerner Corporation
 [@StephenEsser]: https://github.com/StephenEsser
 [@benbcai]: https://github.com/benbcai
 [@tbiethman]: https://github.com/tbiethman
+[@yuderekyu]: https://github.com/yuderekyu

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -61,7 +61,7 @@ module.exports = {
       },
     },
     {
-      files: ['**/wdio/**/*-spec.*'],
+      files: ['**/wdio/**/*-spec.*', '**/full-stack/**/*-spec.*'],
       rules: {
         'no-unused-expressions': 'off',
       },


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->
Add full stack spec glob to lint overrides. this will ignore undefined global lint errors for our testing globals

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->
ideally, full-stack and component level wdio testing should not diverge on what testing technologies they use (mocha, visual regression, etc)
@cerner/terra
<!-- If you haven't done so already, please...
full stack testing has access to the same test globals that component level wdio use. i see these remaining in alignment in the future

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
